### PR TITLE
Refactor/end turn server client communication

### DIFF
--- a/GAME_CONFIG.json
+++ b/GAME_CONFIG.json
@@ -8,5 +8,6 @@
     "minCardAttack": 5,
     "maxCardAttack": 9,
     "minCardLife": 10,
-    "maxCardLife": 18
+    "maxCardLife": 18,
+    "secondsPerTurn": 120
 }

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -101,13 +101,14 @@ const App = () => {
 			});
 		});
 		state.socket.on('player-joined', (game) => {
+			console.log('player-joined', game);
+
 			dispatch({
 				type: 'SET_GAME',
 				payload: {
 					game,
 				},
 			});
-			console.log('game', game);
 			history.push('/game');
 		});
 	};

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -190,7 +190,7 @@ export default () => {
 	useEffect(() => {
 		const countdownTimer = setTimeout(() => {
 			console.log('setTimeout running', turnCountdownTimer);
-			if (turnCountdownTimer <= 0) {
+			if (turnCountdownTimer <= 0 && !state.isOtherPlayerTurn) {
 				endTurn();
 				setTurnCountdownTimer(SECONDS_PER_TURN);
 				return;

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -185,7 +185,7 @@ export default () => {
 	}, []);
 
 	/**
-	 * @dev On render and start-turn a timer will countdown how long left the player has to make a move
+	 * @dev On render and new-turn a timer will countdown how long left the player has to make a move
 	 */
 	useEffect(() => {
 		const countdownTimer = setTimeout(() => {
@@ -416,23 +416,33 @@ export default () => {
 				});
 			}
 		});
-		state.socket.on('start-turn', (data) => {
-			const payload = {
-				isOtherPlayerTurn: false,
-			};
-			if (data.game) {
+		state.socket.on('new-turn', (data) => {
+			const game = data.game;
+
+			if (state.playerNumber === game.currentPlayerTurn) {
 				dispatch({
-					type: 'SET_GAME',
+					type: 'SET_IS_OTHER_PLAYER_TURN',
 					payload: {
-						game: data.game,
+						isOtherPlayerTurn: false,
+					},
+				});
+				drawCard();
+			} else {
+				dispatch({
+					type: 'SET_IS_OTHER_PLAYER_TURN',
+					payload: {
+						isOtherPlayerTurn: true,
 					},
 				});
 			}
+
 			dispatch({
-				type: 'SET_IS_OTHER_PLAYER_TURN',
-				payload,
+				type: 'SET_GAME',
+				payload: {
+					game,
+				},
 			});
-			drawCard();
+
 			// Restarts the countdown timer
 			setTurnCountdownTimer(SECONDS_PER_TURN);
 		});

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -563,69 +563,6 @@ export default () => {
 		});
 	};
 
-	const getDamageMultiplier = (attackerType, victimType) => {
-		// this.globalCardTypes = ['fire', 'water', 'wind', 'life', 'death', 'neutral']
-		let damageMultiplier = 1;
-		switch (attackerType) {
-			case 'fire':
-				if (victimType == 'wind') damageMultiplier = 2;
-				else if (
-					victimType == 'water' ||
-					victimType == 'life' ||
-					victimType == 'death'
-				)
-					damageMultiplier = 0.5;
-				break;
-			case 'wind':
-				if (victimType == 'water') damageMultiplier = 2;
-				else if (
-					victimType == 'fire' ||
-					victimType == 'life' ||
-					victimType == 'death'
-				)
-					damageMultiplier = 0.5;
-				break;
-			case 'water':
-				if (victimType == 'fire') damageMultiplier = 2;
-				else if (
-					victimType == 'wind' ||
-					victimType == 'life' ||
-					victimType == 'death'
-				)
-					damageMultiplier = 0.5;
-				break;
-			case 'life':
-				if (
-					victimType == 'fire' ||
-					victimType == 'wind' ||
-					victimType == 'water' ||
-					victimType == 'neutral'
-				)
-					damageMultiplier = 2;
-				break;
-			case 'death':
-				if (
-					victimType == 'fire' ||
-					victimType == 'wind' ||
-					victimType == 'water' ||
-					victimType == 'neutral'
-				)
-					damageMultiplier = 2;
-				break;
-			case 'neutral':
-				if (
-					victimType == 'fire' ||
-					victimType == 'wind' ||
-					victimType == 'water' ||
-					victimType == 'life' ||
-					victimType == 'death'
-				)
-					damageMultiplier = 0.5;
-				break;
-		}
-		return damageMultiplier;
-	};
-
 	/**
 	 * @dev Handles the logic for attacking the enemy field card
 	 */

--- a/src/client/components/Store.js
+++ b/src/client/components/Store.js
@@ -46,10 +46,14 @@ const StateProvider = ({ children }) => {
 				return newState;
 			case 'SET_IS_OTHER_PLAYER_TURN':
 				console.log('set is other player turn');
+
 				newState = {
 					...state,
 					isOtherPlayerTurn: action.payload.isOtherPlayerTurn,
 				};
+				if (action.payload.game) {
+					newState.game = action.payload.game;
+				}
 				return newState;
 			case 'SET_GAME_OVER':
 				console.log('set game over');
@@ -83,10 +87,15 @@ const StateProvider = ({ children }) => {
 				return newState;
 			case 'SET_GAME':
 				console.log('set game', action.payload.game);
+
 				newState = {
 					...state,
 					game: action.payload.game,
 				};
+				if (action.payload.isOtherPlayerTurn) {
+					newState.isOtherPlayerTurn =
+						action.payload.isOtherPlayerTurn;
+				}
 				return newState;
 			case 'SET_GAME_LIST':
 				console.log('set game list');

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -168,6 +168,8 @@ io.on('connection', async (socket) => {
 						'player2.hand': cardsPlayer2,
 						'player2.account': data.account,
 						'player2.socketId': socket.id,
+						gameStartTimestamp: Date.now(),
+						currentTurnNumber: 1,
 					},
 				},
 				{
@@ -339,68 +341,101 @@ io.on('connection', async (socket) => {
 		} catch (e) {}
 	});
 	socket.on('end-turn', async (data) => {
+		console.log('end-turn', data.currentGameID);
+		const { currentGameID } = data;
+		let currentGame;
+
+		// Check if the game exists
+		try {
+			currentGame = await db.collection('games').findOne({
+				gameId: currentGameID,
+			});
+		} catch (e) {
+			return socket.emit(
+				'user-error',
+				'#28 Game not found from the given game ID',
+			);
+		}
 		// Check if users are still active
 		const stillActive = checkActiveSockets(
-			data.game.player1.socketId,
-			data.game.player2.socketId,
+			currentGame.player1.socketId,
+			currentGame.player2.socketId,
 		);
 		if (!stillActive) return;
-		const playerNumber = getPlayerNumber(socket.id, data.game);
+
+		const playerNumber = getPlayerNumber(socket.id, currentGame);
 		let updatedCanAttackField;
 		let set = {
-			'player1.turn': data.game.player1.turn,
-			'player1.field': data.game.player1.field,
-			'player2.turn': data.game.player2.turn,
-			'player2.field': data.game.player2.field,
+			'player1.turn': currentGame.player1.turn++,
+			'player1.field': currentGame.player1.field,
+			'player2.turn': currentGame.player2.turn++,
+			'player2.field': currentGame.player2.field,
+			currentTurnNumber: currentGame.currentTurnNumber + 1,
 		};
+
+		console.log('set', set);
 		if (playerNumber === 0) {
 			return socket.emit(
 				'user-error',
 				'#21 You are not a player of this particular game',
 			);
 		} else if (playerNumber === 1) {
-			updatedCanAttackField = data.game.player2.field.map((card) => {
+			updatedCanAttackField = currentGame.player2.field.map((card) => {
 				card.canAttack = true;
 				return card;
 			});
-			set = {
-				'player2.field': updatedCanAttackField,
-				'player2.energy':
-					data.game.player2.energy + GAME_CONFIG.energyPerTurn,
-			};
+			set['player2.field'] = updatedCanAttackField;
+			set['player2.energy'] =
+				currentGame.player2.energy + GAME_CONFIG.energyPerTurn;
 		} else {
-			updatedCanAttackField = data.game.player1.field.map((card) => {
+			updatedCanAttackField = currentGame.player1.field.map((card) => {
 				card.canAttack = true;
 				return card;
 			});
-			set = {
-				'player1.field': updatedCanAttackField,
-				'player1.energy':
-					data.game.player1.energy + GAME_CONFIG.energyPerTurn,
-			};
+			set['player1.field'] = updatedCanAttackField;
+			set['player1.energy'] =
+				currentGame.player1.energy + GAME_CONFIG.energyPerTurn;
 		}
 		// Update other player's field cards to set canAttack to true
 		// Send start turn to the other player with the updated game
+		let updatedGame;
 		try {
 			await db.collection('games').findOneAndUpdate(
 				{
-					gameId: data.game.gameId,
+					gameId: currentGame.gameId,
 				},
 				{
 					$set: set,
 				},
 			);
+			updatedGame = await db.collection('games').findOne({
+				gameId: currentGameID,
+			});
 		} catch (e) {
 			return socket.emit(
 				'user-error',
 				'#25 Error ending turn, try again',
 			);
 		}
+
+		console.log('updatedGame', updatedGame);
 		// Send the start turn
 		if (playerNumber === 1) {
-			io.to(data.game.player2.socketId).emit('start-turn');
+			io.to(currentGame.player2.socketId).emit('start-turn', {
+				game: updatedGame,
+			});
+			io.to(currentGame.player1.socketId).emit('set-state', {
+				game: updatedGame,
+				isOtherPlayerTurn: true,
+			});
 		} else {
-			io.to(data.game.player1.socketId).emit('start-turn');
+			io.to(currentGame.player1.socketId).emit('start-turn', {
+				game: updatedGame,
+			});
+			io.to(currentGame.player2.socketId).emit('set-state', {
+				game: updatedGame,
+				isOtherPlayerTurn: true,
+			});
 		}
 	});
 	socket.on('draw-card', async (data) => {
@@ -572,15 +607,15 @@ io.on('connection', async (socket) => {
 			game: final.value,
 		});
 	});
-	socket.on("attacked-field", async (data) => {
-		console.log("attack field BY", socket.id);
+	socket.on('attacked-field', async (data) => {
+		console.log('attack field BY', socket.id);
 
 		const { currentGameID, attackingCardID, enemyCardID } = data;
 		let currentGame;
 
 		// Check if the game exists
 		try {
-			currentGame = await db.collection("games").findOne({
+			currentGame = await db.collection('games').findOne({
 				gameId: currentGameID,
 			});
 		} catch (e) {
@@ -593,7 +628,7 @@ io.on('connection', async (socket) => {
 		// Check if users are still active
 		const stillActive = checkActiveSockets(
 			currentGame.player1.socketId,
-			currentGame.player2.socketId
+			currentGame.player2.socketId,
 		);
 		if (!stillActive) return;
 
@@ -608,10 +643,10 @@ io.on('connection', async (socket) => {
 
 		const { ally, enemy } = getAllyAndEnemy(playerNumber, currentGame);
 		const attackingCard = ally.field.find(
-			(currentCard) => currentCard.id === attackingCardID
+			(currentCard) => currentCard.id === attackingCardID,
 		);
 		const enemyCard = enemy.field.find(
-			(currentCard) => currentCard.id === enemyCardID
+			(currentCard) => currentCard.id === enemyCardID,
 		);
 
 		const attackingCardIndex = ally.field.indexOf(attackingCard);
@@ -619,25 +654,25 @@ io.on('connection', async (socket) => {
 
 		if (!attackingCard) {
 			return socket.emit(
-				"user-error",
-				"#50 Attacking card could not be found"
+				'user-error',
+				'#50 Attacking card could not be found',
 			);
 		}
 
 		if (!enemyCard) {
 			return socket.emit(
-				"user-error",
-				"#50 Enemy card could not be found"
+				'user-error',
+				'#50 Enemy card could not be found',
 			);
 		}
 
 		const attackingDamageMultiplier = getCardDamageMultiplier(
 			attackingCard.type,
-			enemyCard.type
+			enemyCard.type,
 		);
 		const ememyDamageMultiplier = getCardDamageMultiplier(
 			enemyCard.type,
-			attackingCard.type
+			attackingCard.type,
 		);
 
 		// Reduce attacker's and receiver's card life
@@ -665,8 +700,8 @@ io.on('connection', async (socket) => {
 				},
 				{
 					$set: {
-						"player1.field": currentGame.player1.field,
-						"player2.field": currentGame.player2.field,
+						'player1.field': currentGame.player1.field,
+						'player2.field': currentGame.player2.field,
 					},
 				},
 				{
@@ -680,22 +715,22 @@ io.on('connection', async (socket) => {
 			);
 		}
 
-		io.to(currentGame.player2.socketId).emit("attack-field-received", {
+		io.to(currentGame.player2.socketId).emit('attack-field-received', {
 			game: final.value,
 		});
-		io.to(currentGame.player1.socketId).emit("attack-field-received", {
+		io.to(currentGame.player1.socketId).emit('attack-field-received', {
 			game: final.value,
 		});
 	});
-	socket.on("attack-direct", async (data) => {
-		console.log("attack direct BY", socket.id);
+	socket.on('attack-direct', async (data) => {
+		console.log('attack direct BY', socket.id);
 
 		const { currentGameID, attackingCardID } = data;
 		let currentGame;
 
 		// Check if the game exists
 		try {
-			currentGame = await db.collection("games").findOne({
+			currentGame = await db.collection('games').findOne({
 				gameId: currentGameID,
 			});
 		} catch (e) {
@@ -708,7 +743,7 @@ io.on('connection', async (socket) => {
 		// Check if users are still active
 		const stillActive = checkActiveSockets(
 			currentGame.player1.socketId,
-			currentGame.player2.socketId
+			currentGame.player2.socketId,
 		);
 		if (!stillActive) return;
 
@@ -723,13 +758,13 @@ io.on('connection', async (socket) => {
 
 		const { ally, enemy } = getAllyAndEnemy(playerNumber, currentGame);
 		const attackingCard = ally.field.find(
-			(currentCard) => currentCard.id === attackingCardID
+			(currentCard) => currentCard.id === attackingCardID,
 		);
 
 		if (!attackingCard) {
 			return socket.emit(
-				"user-error",
-				"#50 Attacking card could not be found"
+				'user-error',
+				'#50 Attacking card could not be found',
 			);
 		}
 
@@ -747,18 +782,18 @@ io.on('connection', async (socket) => {
 			winner = playerNumber;
 			set = {
 				status: GAME_STATUS.ENDED,
-				"player1.field": currentGame.player1.field,
-				"player1.life": currentGame.player1.life,
-				"player2.field": currentGame.player2.field,
-				"player2.life": currentGame.player2.life,
+				'player1.field': currentGame.player1.field,
+				'player1.life': currentGame.player1.life,
+				'player2.field': currentGame.player2.field,
+				'player2.life': currentGame.player2.life,
 				gamePaused: true,
 			};
 		} else {
 			set = {
-				"player1.field": currentGame.player1.field,
-				"player1.life": currentGame.player1.life,
-				"player2.field": currentGame.player2.field,
-				"player2.life": currentGame.player2.life,
+				'player1.field': currentGame.player1.field,
+				'player1.life': currentGame.player1.life,
+				'player2.field': currentGame.player2.field,
+				'player2.life': currentGame.player2.life,
 			};
 		}
 		try {
@@ -783,10 +818,10 @@ io.on('connection', async (socket) => {
 		// End the game
 		if (isGameOver) return endGame(io, final.value, winner);
 
-		io.to(currentGame.player2.socketId).emit("attack-direct-received", {
+		io.to(currentGame.player2.socketId).emit('attack-direct-received', {
 			game: final.value,
 		});
-		io.to(currentGame.player1.socketId).emit("attack-direct-received", {
+		io.to(currentGame.player1.socketId).emit('attack-direct-received', {
 			game: final.value,
 		});
 	});
@@ -833,58 +868,58 @@ const getCardDamageMultiplier = (attackerType, victimType) => {
 	// this.globalCardTypes = ['fire', 'water', 'wind', 'life', 'death', 'neutral']
 	let damageMultiplier = 1;
 	switch (attackerType) {
-		case "fire":
-			if (victimType == "wind") damageMultiplier = 2;
+		case 'fire':
+			if (victimType == 'wind') damageMultiplier = 2;
 			else if (
-				victimType == "water" ||
-				victimType == "life" ||
-				victimType == "death"
+				victimType == 'water' ||
+				victimType == 'life' ||
+				victimType == 'death'
 			)
 				damageMultiplier = 0.5;
 			break;
-		case "wind":
-			if (victimType == "water") damageMultiplier = 2;
+		case 'wind':
+			if (victimType == 'water') damageMultiplier = 2;
 			else if (
-				victimType == "fire" ||
-				victimType == "life" ||
-				victimType == "death"
+				victimType == 'fire' ||
+				victimType == 'life' ||
+				victimType == 'death'
 			)
 				damageMultiplier = 0.5;
 			break;
-		case "water":
-			if (victimType == "fire") damageMultiplier = 2;
+		case 'water':
+			if (victimType == 'fire') damageMultiplier = 2;
 			else if (
-				victimType == "wind" ||
-				victimType == "life" ||
-				victimType == "death"
+				victimType == 'wind' ||
+				victimType == 'life' ||
+				victimType == 'death'
 			)
 				damageMultiplier = 0.5;
 			break;
-		case "life":
+		case 'life':
 			if (
-				victimType == "fire" ||
-				victimType == "wind" ||
-				victimType == "water" ||
-				victimType == "neutral"
+				victimType == 'fire' ||
+				victimType == 'wind' ||
+				victimType == 'water' ||
+				victimType == 'neutral'
 			)
 				damageMultiplier = 2;
 			break;
-		case "death":
+		case 'death':
 			if (
-				victimType == "fire" ||
-				victimType == "wind" ||
-				victimType == "water" ||
-				victimType == "neutral"
+				victimType == 'fire' ||
+				victimType == 'wind' ||
+				victimType == 'water' ||
+				victimType == 'neutral'
 			)
 				damageMultiplier = 2;
 			break;
-		case "neutral":
+		case 'neutral':
 			if (
-				victimType == "fire" ||
-				victimType == "wind" ||
-				victimType == "water" ||
-				victimType == "life" ||
-				victimType == "death"
+				victimType == 'fire' ||
+				victimType == 'wind' ||
+				victimType == 'water' ||
+				victimType == 'life' ||
+				victimType == 'death'
 			)
 				damageMultiplier = 0.5;
 			break;
@@ -1023,11 +1058,11 @@ const generateInitialCards = () => {
 
 const endGame = (io, game, winner) => {
 	// Send the winner emit event
-	io.to(game.player1.socketId).emit("game-over", {
+	io.to(game.player1.socketId).emit('game-over', {
 		winner,
 		game,
 	});
-	io.to(game.player2.socketId).emit("game-over", {
+	io.to(game.player2.socketId).emit('game-over', {
 		winner,
 		game,
 	});

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -366,10 +366,12 @@ io.on('connection', async (socket) => {
 		const playerNumber = getPlayerNumber(socket.id, currentGame);
 		let updatedCanAttackField;
 		let set = {
-			'player1.turn': currentGame.player1.turn++,
+			'player1.turn': currentGame.player1.turn,
 			'player1.field': currentGame.player1.field,
-			'player2.turn': currentGame.player2.turn++,
+			'player1.hand': currentGame.player1.hand,
+			'player2.turn': currentGame.player2.turn,
 			'player2.field': currentGame.player2.field,
+			'player2.hand': currentGame.player2.hand,
 			currentTurnNumber: currentGame.currentTurnNumber + 1,
 		};
 
@@ -387,6 +389,9 @@ io.on('connection', async (socket) => {
 			set['player2.field'] = updatedCanAttackField;
 			set['player2.energy'] =
 				currentGame.player2.energy + GAME_CONFIG.energyPerTurn;
+			set['player2.turn'] += 1;
+			//TODO: Add a fake card for visual purposes
+			// set['player2.hand'].push({});
 		} else {
 			updatedCanAttackField = currentGame.player1.field.map((card) => {
 				card.canAttack = true;
@@ -395,6 +400,9 @@ io.on('connection', async (socket) => {
 			set['player1.field'] = updatedCanAttackField;
 			set['player1.energy'] =
 				currentGame.player1.energy + GAME_CONFIG.energyPerTurn;
+			set['player1.turn'] += 1;
+			//TODO: Add a fake card for visual purposes
+			// set['player1.hand'].push({});
 		}
 		// Update other player's field cards to set canAttack to true
 		// Send start turn to the other player with the updated game

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -52,9 +52,9 @@ app.use('*', (req, res, next) => {
 });
 
 app.post('/github-push', (req, res) => {
-	exec('yarn pull && pm2 restart all', (err, stderr, stout) => {})
-	res.status(200).send("Ok")
-})
+	exec('yarn pull && pm2 restart all', (err, stderr, stout) => {});
+	res.status(200).send('Ok');
+});
 
 app.get('/build.js', (req, res) => {
 	return res.sendFile(path.join(__dirname, '../../dist/build.js'));
@@ -175,6 +175,8 @@ io.on('connection', async (socket) => {
 						'player2.socketId': socket.id,
 						gameStartTimestamp: Date.now(),
 						currentTurnNumber: 1,
+						currentPlayerTurn: 1,
+						currentTurnStartTimestamp: Date.now(),
 					},
 				},
 				{
@@ -378,9 +380,10 @@ io.on('connection', async (socket) => {
 			'player2.field': currentGame.player2.field,
 			'player2.hand': currentGame.player2.hand,
 			currentTurnNumber: currentGame.currentTurnNumber + 1,
+			currentPlayerTurn: swapPlayerTurn(currentGame.currentPlayerTurn),
+			currentTurnStartTimestamp: Date.now(),
 		};
 
-		console.log('set', set);
 		if (playerNumber === 0) {
 			return socket.emit(
 				'user-error',
@@ -432,24 +435,13 @@ io.on('connection', async (socket) => {
 		}
 
 		console.log('updatedGame', updatedGame);
-		// Send the start turn
-		if (playerNumber === 1) {
-			io.to(currentGame.player2.socketId).emit('start-turn', {
-				game: updatedGame,
-			});
-			io.to(currentGame.player1.socketId).emit('set-state', {
-				game: updatedGame,
-				isOtherPlayerTurn: true,
-			});
-		} else {
-			io.to(currentGame.player1.socketId).emit('start-turn', {
-				game: updatedGame,
-			});
-			io.to(currentGame.player2.socketId).emit('set-state', {
-				game: updatedGame,
-				isOtherPlayerTurn: true,
-			});
-		}
+		// Notify client of the start of new turn
+		io.to(currentGame.player1.socketId).emit('new-turn', {
+			game: updatedGame,
+		});
+		io.to(currentGame.player2.socketId).emit('new-turn', {
+			game: updatedGame,
+		});
 	});
 	socket.on('draw-card', async (data) => {
 		console.log('draw hand BY', socket.id);
@@ -856,6 +848,7 @@ const getPlayerNumber = (socketId, game) => {
  *
  * @param {Number} playerNumber The player number, valid values are 1 or 2
  * @param {Object} game The current game object
+ * @returns {Object} returns the ally and enemy object
  */
 const getAllyAndEnemy = (playerNumber, game) => {
 	let ally,
@@ -876,6 +869,7 @@ const getAllyAndEnemy = (playerNumber, game) => {
  * @dev Calculates the damage multiplier based on Card Type
  * @param { String } attackerType
  * @param { String } victimType
+ * @returns { Number } damageMultiplier - based on card types
  */
 const getCardDamageMultiplier = (attackerType, victimType) => {
 	// this.globalCardTypes = ['fire', 'water', 'wind', 'life', 'death', 'neutral']
@@ -938,6 +932,15 @@ const getCardDamageMultiplier = (attackerType, victimType) => {
 			break;
 	}
 	return damageMultiplier;
+};
+
+/**
+ * @dev Swaps the player turn, if the previous turn was Player1's turn then we swap it to Player2
+ * @param {Number} currentPlayerTurn
+ * @returns {Number} newPlayerTurn
+ */
+const swapPlayerTurn = (currentPlayerTurn) => {
+	return currentPlayerTurn === 1 ? 2 : 1;
 };
 
 // Returns false if one or more are innactive


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28586597/100869916-bb024300-34d8-11eb-91ac-cfbbe15ab9ef.png)

At the moment on end-turn the server will only update a SINGLE client, this could cause data to be out of sync, especially with things such as a countdown timer 

This has been updated so that both clients will be updated with the new game data. This is done by:
- Removing the 'start-turn' socket event where it only updated a SINGLE client
- Adding a 'new-turn' socket event where it updates both clients of the updated game data

Other changes:
- Removed getDamageMultiplier from client-side as that is now being handled on the server
- Added return type comments on server-side functions for better maintainability
- Added new server-side function 'swapPlayerTurn' to swap the players turn after the end of a turn
- Added two new data fields to the Game Object
    - currentPlayerTurn - To store whose turn it is
    - currentTurnStartTimestamp - epoch timestamp so that we can keep the countdown timer in sync
