### PR TITLE
Security/hide opponent player hand

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"dotenv-safe": "^8.2.0",
 		"ethereumjs-abi": "^0.6.8",
 		"express": "^4.17.1",
+		"lodash.clonedeep": "^4.5.0",
 		"mongodb": "^3.6.3",
 		"socket.io": "^2.2.0",
 		"socket.io-client": "^2.2.0",

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -514,26 +514,6 @@ export default () => {
 
 	const endTurn = () => {
 		toggleAttackMode(0)
-		const game = { ...state.game }
-
-		if (state.playerNumber === 1) {
-			// Add a fake card for visual purposes
-			if (game.player2.hand.length < HAND_SIZE) {
-				game.player2.hand.push({})
-			}
-		} else {
-			// Add a fake card for visual purposes
-			if (game.player1.hand.length < HAND_SIZE) {
-				game.player1.hand.push({})
-			}
-		}
-
-		dispatch({
-			type: 'SET_GAME',
-			payload: {
-				game,
-			},
-		})
 
 		dispatch({
 			type: 'SET_IS_OTHER_PLAYER_TURN',

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -479,11 +479,11 @@ export default () => {
 				},
 			})
 		})
-		state.socket.on('attack-field-received', (data) => {
+		state.socket.on('attack-field-received', (game) => {
 			dispatch({
 				type: 'SET_GAME',
 				payload: {
-					game: data.game,
+					game,
 				},
 			})
 		})

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -487,11 +487,11 @@ export default () => {
 				},
 			})
 		})
-		state.socket.on('attack-direct-received', (data) => {
+		state.socket.on('attack-direct-received', (game) => {
 			dispatch({
 				type: 'SET_GAME',
 				payload: {
-					game: data.game,
+					game,
 				},
 			})
 		})

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -171,8 +171,8 @@ export default () => {
 	const [gameOver, setGameOver] = useState(null)
 	const [turnCountdownTimer, setTurnCountdownTimer] = useState(
 		SECONDS_PER_TURN,
-	);
-	const isGamePaused = () => state.game && state.game.gamePaused;
+	)
+	const isGamePaused = () => state.game && state.game.gamePaused
 
 	useEffect(() => {
 		if (state.playerNumber === 2) {
@@ -191,14 +191,14 @@ export default () => {
 	 */
 	useEffect(() => {
 		const countdownTimer = setTimeout(() => {
-      console.log('isGamePaused()', isGamePaused())
-			if (isGamePaused()) return;
+			console.log('isGamePaused()', isGamePaused())
+			if (isGamePaused()) return
 
 			const turnTimeLimit = new Date(
 				state.game.currentTurnTimeLimitTimestamp,
-			);
+			)
 
-			console.log('setTimeout running', turnCountdownTimer);
+			console.log('setTimeout running', turnCountdownTimer)
 
 			if (turnCountdownTimer <= 0 && !state.isOtherPlayerTurn) {
 				endTurn()
@@ -207,15 +207,15 @@ export default () => {
 			}
 			const newTime = Math.ceil(
 				(turnTimeLimit.getTime() - Date.now()) / 1000,
-			);
+			)
 
 			// If for whatever reason the newTime is negative we will set it to 0
 			if (newTime < 0) {
-				setTurnCountdownTimer(0);
-				return;
+				setTurnCountdownTimer(0)
+				return
 			}
-			setTurnCountdownTimer(newTime);
-		}, 1000);
+			setTurnCountdownTimer(newTime)
+		}, 1000)
 		return () => {
 			clearTimeout(countdownTimer)
 		}
@@ -435,9 +435,7 @@ export default () => {
 				})
 			}
 		})
-		state.socket.on('new-turn', (data) => {
-			const game = data.game
-
+		state.socket.on('new-turn', (game) => {
 			if (state.playerNumber === game.currentPlayerTurn) {
 				dispatch({
 					type: 'SET_IS_OTHER_PLAYER_TURN',

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -463,11 +463,11 @@ export default () => {
 			// Restarts the countdown timer
 			setTurnCountdownTimer(SECONDS_PER_TURN)
 		})
-		state.socket.on('draw-card-received', (data) => {
+		state.socket.on('draw-card-received', (game) => {
 			dispatch({
 				type: 'SET_GAME',
 				payload: {
-					game: data.game,
+					game,
 				},
 			})
 		})

--- a/src/client/components/GamePage.js
+++ b/src/client/components/GamePage.js
@@ -471,11 +471,11 @@ export default () => {
 				},
 			})
 		})
-		state.socket.on('card-invoke-received', (data) => {
+		state.socket.on('card-invoke-received', (game) => {
 			dispatch({
 				type: 'SET_GAME',
 				payload: {
-					game: data.game,
+					game,
 				},
 			})
 		})

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -198,7 +198,8 @@ io.on('connection', async (socket) => {
 			)
 		}
 
-		updateBothClientsGameData(
+		//Securely updates both clients of new game data
+		securelyUpdateBothClientsGameData(
 			game.value.player1.socketId,
 			game.value.player2.socketId,
 			game.value,
@@ -402,8 +403,8 @@ io.on('connection', async (socket) => {
 
 		console.log('updatedGame', updatedGame)
 
-		// Notify client of the start of new turn
-		updateBothClientsGameData(
+		// Securely notify both clients of the start of new turn
+		securelyUpdateBothClientsGameData(
 			currentGame.player1.socketId,
 			currentGame.player2.socketId,
 			updatedGame,
@@ -495,7 +496,7 @@ io.on('connection', async (socket) => {
 		}
 
 		//Securely updates both clients of new game data
-		updateBothClientsGameData(
+		securelyUpdateBothClientsGameData(
 			data.game.player1.socketId,
 			data.game.player2.socketId,
 			updatedGame,
@@ -584,7 +585,7 @@ io.on('connection', async (socket) => {
 		}
 
 		//Securely updates both clients of new game data
-		updateBothClientsGameData(
+		securelyUpdateBothClientsGameData(
 			data.game.player1.socketId,
 			data.game.player2.socketId,
 			final.value,
@@ -698,7 +699,7 @@ io.on('connection', async (socket) => {
 		}
 
 		//Securely updates both clients of new game data
-		updateBothClientsGameData(
+		securelyUpdateBothClientsGameData(
 			currentGame.player1.socketId,
 			currentGame.player2.socketId,
 			final.value,
@@ -800,7 +801,7 @@ io.on('connection', async (socket) => {
 		if (isGameOver) return endGame(io, final.value, winner)
 
 		//Securely updates both clients of new game data
-		updateBothClientsGameData(
+		securelyUpdateBothClientsGameData(
 			currentGame.player1.socketId,
 			currentGame.player2.socketId,
 			final.value,
@@ -1086,7 +1087,7 @@ const start = async () => {
  * @param {Object} io
  * @returns void
  */
-const updateBothClientsGameData = (
+const securelyUpdateBothClientsGameData = (
 	player1SocketID,
 	player2SocketID,
 	game,

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1107,9 +1107,6 @@ const securelyUpdateBothClientsGameData = (
 		() => ({}),
 	)
 
-	console.log('player1GameObject', player1GameObject)
-	console.log('player2GameObject', player2GameObject)
-
 	// Updating clients
 	io.to(player1SocketID).emit(eventName, player1GameObject)
 	io.to(player2SocketID).emit(eventName, player2GameObject)

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -692,9 +692,16 @@ io.on('connection', async (socket) => {
 			)
 		} catch (e) {
 			return socket.emit('user-error', '#31 Error updating the game data')
-    }
-    
-    updateBothClientsGameData(currentGame.player1.socketId, currentGame.player2.socketId, final.value, io, 'attack-field-received')
+		}
+
+		//Securely updates both clients of new game data
+		updateBothClientsGameData(
+			currentGame.player1.socketId,
+			currentGame.player2.socketId,
+			final.value,
+			io,
+			'attack-field-received',
+		)
 	})
 	socket.on('attack-direct', async (data) => {
 		console.log('attack direct BY', socket.id)
@@ -789,12 +796,14 @@ io.on('connection', async (socket) => {
 		// End the game
 		if (isGameOver) return endGame(io, final.value, winner)
 
-		io.to(currentGame.player2.socketId).emit('attack-direct-received', {
-			game: final.value,
-		})
-		io.to(currentGame.player1.socketId).emit('attack-direct-received', {
-			game: final.value,
-		})
+		//Securely updates both clients of new game data
+		updateBothClientsGameData(
+			currentGame.player1.socketId,
+			currentGame.player2.socketId,
+			final.value,
+			io,
+			'attack-direct-received',
+		)
 	})
 })
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -466,9 +466,6 @@ io.on('connection', async (socket) => {
 					'#26 Error updating the player hand after drawing',
 				)
 			}
-			io.to(data.game.player1.socketId).emit('draw-card-received', {
-				game: updatedGame,
-			})
 		} else {
 			copyHand = updatedGame.player2.hand.slice(0)
 			if (copyHand.length < GAME_CONFIG.maxCardsInHand) {
@@ -495,10 +492,16 @@ io.on('connection', async (socket) => {
 					'#27 Error updating the player hand after drawing',
 				)
 			}
-			io.to(data.game.player2.socketId).emit('draw-card-received', {
-				game: updatedGame,
-			})
 		}
+
+		//Securely updates both clients of new game data
+		updateBothClientsGameData(
+			data.game.player1.socketId,
+			data.game.player2.socketId,
+			updatedGame,
+			io,
+			'draw-card-received',
+		)
 	})
 	socket.on('invoke-card', async (data) => {
 		console.log('invoke card BY', socket.id)

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -206,50 +206,6 @@ io.on('connection', async (socket) => {
 			'player-joined',
 		)
 	})
-	socket.on('invoke-card', async (data) => {
-		// Check if users are still active
-		const stillActive = checkActiveSockets(
-			data.game.player1.socketId,
-			data.game.player2.socketId,
-		)
-		const playerNumber = getPlayerNumber(socket.id, data.game)
-		let updateData
-		if (!stillActive) return
-		if (playerNumber === 1) {
-			updateData = {
-				'player1.field': data.game.player1.field,
-				'player1.hand': data.game.player1.hand,
-			}
-		} else if (playerNumber === 2) {
-			updateData = {
-				'player2.field': data.game.player2.field,
-				'player2.hand': data.game.player2.hand,
-			}
-		} else {
-			return socket.emit(
-				'user-error',
-				"#21 You aren't a player of this particular game",
-			)
-		}
-		try {
-			await db.collection('games').updateOne(
-				{
-					gameId: data.game.gameId,
-				},
-				{ $set: updateData },
-			)
-		} catch (e) {
-			return socket.emit(
-				'user-error',
-				'#22 Error updating the game data with the card invoke',
-			)
-		}
-		if (playerNumber === 1) {
-			io.to(data.game.player1.socketId).emit('invoke-player1', data.game)
-		} else {
-			io.to(data.game.player2.socketId).emit('invoke-player2', data.game)
-		}
-	})
 	socket.on('update-game', async (data) => {
 		// Update-game is an event that indicates a single change such as ending a turn,
 		// invoking a card, attacking directly or to the field or drawing a card

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -692,14 +692,9 @@ io.on('connection', async (socket) => {
 			)
 		} catch (e) {
 			return socket.emit('user-error', '#31 Error updating the game data')
-		}
-
-		io.to(currentGame.player2.socketId).emit('attack-field-received', {
-			game: final.value,
-		})
-		io.to(currentGame.player1.socketId).emit('attack-field-received', {
-			game: final.value,
-		})
+    }
+    
+    updateBothClientsGameData(currentGame.player1.socketId, currentGame.player2.socketId, final.value, io, 'attack-field-received')
 	})
 	socket.on('attack-direct', async (data) => {
 		console.log('attack direct BY', socket.id)

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -579,12 +579,15 @@ io.on('connection', async (socket) => {
 				'#29 Error updating the field with the invoked card',
 			)
 		}
-		io.to(data.game.player1.socketId).emit('card-invoke-received', {
-			game: final.value,
-		})
-		return io.to(data.game.player2.socketId).emit('card-invoke-received', {
-			game: final.value,
-		})
+
+		//Securely updates both clients of new game data
+		updateBothClientsGameData(
+			data.game.player1.socketId,
+			data.game.player2.socketId,
+			final.value,
+			io,
+			'card-invoke-received',
+		)
 	})
 	socket.on('attacked-field', async (data) => {
 		console.log('attack field BY', socket.id)


### PR DESCRIPTION
**Problem**:
Referring to the image below, we can see that the player can view their opponent's hand by looking at the network tab.

![image](https://user-images.githubusercontent.com/28586597/100962985-728e6800-3560-11eb-99dd-ddb6274483f1.png)

This PR ensures that it is no longer possible by only giving each client access to game data that is only **relevant** to them:
![image](https://user-images.githubusercontent.com/28586597/100963082-9ce02580-3560-11eb-978a-e24498efaf4d.png)

Actions that were updated:
- join-game
- invoke-card
- attack-field
- attack-direct
- draw-card
- end-turn

Other side-effects from this PR:
1. Number of cards on enemy hand properly updates now 
    -  This issue was caused because the 'invoke-card' action only updates a single Client. This is now resolved as the 'invoke-'card action will update both clients with their relevant game data